### PR TITLE
Added new alias

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -12,5 +12,5 @@ main: de.matzefratze123.heavyspleef.HeavySpleef
 
 commands:
   spleef:
-    aliases: [hs, hspleef, spl]
+    aliases: [hs, hspleef, spl, splegg]
     description: General Spleef command for HeavySpleef


### PR DESCRIPTION
The reason why i find this usefull is so i don't have to edit it myself everytime i update HeavySpleef.
This will also make more sense since you added support for a Splegg alias in signs, so when you can join a sign named
[Splegg]
Join
Why shouldn't you be able to write /splegg leave ? If then it begins to be a problem with conflicting plugins (there is only http://dev.bukkit.org/bukkit-plugins/splegg-game/ and http://dev.bukkit.org/bukkit-plugins/splegg/ which there is no reason to use if you use HeavySpleef)
