### PR TITLE
New name?

### DIFF
--- a/src/main/resources/default/defaultconfig.yml
+++ b/src/main/resources/default/defaultconfig.yml
@@ -107,7 +107,7 @@ flag-defaults:
   maxplayers: 0
   autostart: 0
   countdown: 10
-  jackpotamount: 0
+  entryfee: 0
   reward: 0
   chances: 0
   timeout: 0


### PR DESCRIPTION
According to the wiki: http://dev.bukkit.org/bukkit-plugins/heavyspleef/pages/documentation/english/information/flags-and-their-values/ it should be called this instead.
